### PR TITLE
[DM-23433] Constrain werkzeug version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ DESCRIPTION = 'LSST Data Management SQuaRE microservice tools'
 AUTHOR = 'Adam Thornton'
 AUTHOR_EMAIL = 'athornton@lsst.org'
 URL = 'https://github.com/lsst-sqre/sqre-apikit'
-VERSION = '0.1.2'
+VERSION = '0.1.3'
 LICENSE = 'MIT'
 
 
@@ -45,7 +45,10 @@ setup(
         'Flask==0.11.1',
         'future==0.16.0',
         'requests>=2.13.0,<3.0.0',
-        'structlog>=16.1.0'
+        'structlog>=16.1.0',
+        # Flask <0.12.4 is incompatible with werkzeug>1.0 but doesn't
+        # constrain its version.  The mix produces errors about `is_xhr`.
+        'werkzeug<1.0',
     ],
     tests_require=['pytest'],
 )


### PR DESCRIPTION
Avoid an incompatibility between older versions of Flask and the
new release of werkzeug, since Flask didn't constrain the werkzeug
version.

Release as v0.1.3.