### PR TITLE
Set content type of long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url=URL,
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
The default is rST, but the README.md file is in Markdown.  Set
the content type accordingly.

This was blocking upload of new packages to PyPI.